### PR TITLE
Case 28196: Do not cache /assets/includes/qubit/opentag.html

### DIFF
--- a/qubit_lite.routing.yml
+++ b/qubit_lite.routing.yml
@@ -11,6 +11,8 @@ qubit_lite.cross_domain_tracking:
   path: '/assets/includes/qubit/opentag.html'
   defaults:
     _controller: '\Drupal\qubit_lite\Controller\QubitTrackingController:build'
+  options:
+    no_cache: TRUE
 qubit_lite.biscotti:
   path: '/assets/includes/qubit/biscotti.html'
   defaults:


### PR DESCRIPTION
Set the /assets/includes/qubit/opentag.html path to not cacheable so that the correct IDs are loaded for each site.